### PR TITLE
fix error in incompleate setup of espnow

### DIFF
--- a/ESPNOW_Transmitter/ESPNOW_Transmitter.ino
+++ b/ESPNOW_Transmitter/ESPNOW_Transmitter.ino
@@ -76,7 +76,9 @@ void setup()
   esp_now_register_send_cb(OnDataSent);
   
   // Register peer
-  esp_now_peer_info_t peerInfo;
+//esp_now_peer_info_t peerInfo;
+  esp_now_peer_info_t peerInfo = {};
+
   memcpy(peerInfo.peer_addr, receiverMacAddress, 6);
   peerInfo.channel = 0;  
   peerInfo.encrypt = false;


### PR DESCRIPTION
esp_now_peer_info_t peerInfo = {};

stops error : 
Succes: Initialized ESP-NOW
E (92) ESPNOW: Peer interface is invalid
Failed to add peer
